### PR TITLE
Replace as.POSIXct with fasttime::fastPOSIXct in eddyStampCheck

### DIFF
--- a/neonUtilities/DESCRIPTION
+++ b/neonUtilities/DESCRIPTION
@@ -17,4 +17,4 @@ URL: https://github.com/NEONScience/NEON-utilities
 BugReports: https://github.com/NEONScience/NEON-utilities/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/neonUtilities/DESCRIPTION
+++ b/neonUtilities/DESCRIPTION
@@ -10,7 +10,7 @@ Description: NEON data packages can be accessed through the NEON Data Portal <ht
     data prior to use in analyses. This includes downloading data via the API, merging data tables by type, and 
     converting formats. For more information, see the readme file at <https://github.com/NEONScience/NEON-utilities>.
 Depends: R (>= 4.0.0)
-Imports: httr, jsonlite, downloader, data.table, utils, R.utils, stats, tidyr, stringr, pbapply, parallel, curl
+Imports: httr, jsonlite, downloader, data.table, utils, R.utils, stats, tidyr, stringr, pbapply, parallel, curl, fasttime
 Suggests: rhdf5, terra, testthat
 License: AGPL-3
 URL: https://github.com/NEONScience/NEON-utilities

--- a/neonUtilities/R/eddyStampCheck.R
+++ b/neonUtilities/R/eddyStampCheck.R
@@ -24,11 +24,11 @@ eddyStampCheck <- function(tab){
   tBgnErr <- FALSE
   tEndErr <- FALSE
   
-  tabBP <- try(as.POSIXct(tab$timeBgn, format='%Y-%m-%dT%H:%M:%OS', tz='GMT'), silent=T)
+  tabBP <- try(fasttime::fastPOSIXct(tab$timeBgn, format='%Y-%m-%dT%H:%M:%OS', tz='GMT'), silent=T)
   if(any(c(class(tabBP)=='try-error', all(is.na(tabBP))))) {
     tBgnErr <- TRUE
   }
-  tabEP <- try(as.POSIXct(tab$timeEnd, format='%Y-%m-%dT%H:%M:%OS', tz='GMT'), silent=T)
+  tabEP <- try(fasttime::fastPOSIXct(tab$timeEnd, format='%Y-%m-%dT%H:%M:%OS', tz='GMT'), silent=T)
   if(any(c(class(tabEP)=='try-error', all(is.na(tabEP))))) {
     tEndErr <- TRUE
   }

--- a/neonUtilities/man/eddyStampCheck.Rd
+++ b/neonUtilities/man/eddyStampCheck.Rd
@@ -4,10 +4,14 @@
 \alias{eddyStampCheck}
 \title{Convert date stamps from character and check for only one record in a day}
 \usage{
-eddyStampCheck(tab)
+eddyStampCheck(tab, use_fasttime = FALSE)
 }
 \arguments{
 \item{tab}{A table of SAE data}
+
+\item{use_fasttime}{Logical as to whether to use fasttime::fastPOSIXct to do
+datetime conversions. Increased speed does come at cost of
+decreased precision at the milliseconds level.}
 }
 \value{
 The same table of SAE data, with time stamps converted and empty records representing a single day (filler records inserted during processing) removed.

--- a/neonUtilities/man/stackEddy.Rd
+++ b/neonUtilities/man/stackEddy.Rd
@@ -4,7 +4,14 @@
 \alias{stackEddy}
 \title{Extract eddy covariance data from HDF5 format}
 \usage{
-stackEddy(filepath, level = "dp04", var = NA, avg = NA, metadata = FALSE)
+stackEddy(
+  filepath,
+  level = "dp04",
+  var = NA,
+  avg = NA,
+  metadata = FALSE,
+  use_fasttime = FALSE
+)
 }
 \arguments{
 \item{filepath}{One of: a folder containing NEON EC H5 files, a zip file of DP4.00200.001 data downloaded from the NEON data portal, a folder of DP4.00200.001 data downloaded by the neonUtilities::zipsByProduct() function, or a single NEON EC H5 file [character]}
@@ -16,6 +23,10 @@ stackEddy(filepath, level = "dp04", var = NA, avg = NA, metadata = FALSE)
 \item{avg}{The averaging interval to extract, in minutes [numeric]}
 
 \item{metadata}{Should the output include metadata from the attributes of the H5 files? Defaults to false. Even when false, variable definitions, issue logs, and science review flags will be included. [logical]}
+
+\item{use_fasttime}{Logical as to whether to use fasttime::fastPOSIXct to do
+datetime conversions. Increased speed does come at cost of
+decreased precision at the milliseconds level. Defaults to false.}
 }
 \value{
 A named list of data frames. One data frame per site, plus one data frame containing the metadata (objDesc) table and one data frame containing units for each variable (variables).


### PR DESCRIPTION
Replaces as.POSIXct with fasttime::fastPOSIXct to speed up POSIXct conversions in stackEddy. as.POSIXct seems to slow dramatically when vector to convert is very large - this change cuts runtime for stackEddy on L1/9 minute stack by roughly half.